### PR TITLE
SYN-cookies and loadbalancer

### DIFF
--- a/draft-bonaventure-mptcp-experience.md
+++ b/draft-bonaventure-mptcp-experience.md
@@ -215,7 +215,7 @@ informative:
    target: https://support.apple.com/en-us/HT201373
   FreeBSD-MPTCP:
    author:
-    - ins: . Williams
+    - ins: N. Williams
    title: Multipath TCP For FreeBSD Kernel Patch v0.5
    target:     http://caia.swin.edu.au/urp/newtcp/mptcp  
   INFOCOM14:
@@ -358,7 +358,7 @@ the following platforms :
 
 The first three implementations
 {{I-D.eardley-mptcp-implementations-survey}} are known to
-interoperate. The last twos are currently being tested and improved
+interoperate. The last two are currently being tested and improved
 against the Linux implementation. Three of these implementations are
 open-source. Apple's implementation is widely deployed.
 
@@ -372,7 +372,7 @@ Multipath TCP were identified {{RFC6182}}. Since then, other use cases
 have been proposed and some have been tested and even deployed. We
 describe these use cases in  {{usecases}}.
 
-The second part of the document focuses on the operational
+{{operexp}} focuses on the operational
 experience with Multipath TCP. Most of this experience
 comes from the utilisation of the Multipath TCP implementation
 in the Linux kernel {{MultipathTCP-Linux}}. This
@@ -385,7 +385,7 @@ This Multipath TCP implementation is actively maintained and
 continuously improved. It is used on various types of hosts,
 ranging from smartphones or embedded routers to high-end servers.
 
-The Multipath TCP implementation in the Linux kernel iis not,
+The Multipath TCP implementation in the Linux kernel is not,
 by far, the most widespread deployment of Multipath
 TCP. Since September 2013, Multipath TCP is also supported on
 smartphones and tablets running iOS7 {{IOS7}}. There are likely
@@ -395,7 +395,7 @@ used to support a single application. Unfortunately, there is
 no public information about the lessons learned from this large
 scale deployment.
 
-The second part of this is document is organized as follows.
+{{operexp}} is organized as follows.
 Supporting the middleboxes was one of the difficult issues in
 designing the Multipath TCP protocol. We explain in  {{mbox}}
 which types of middleboxes the Linux Kernel implementation of
@@ -415,7 +415,7 @@ Use cases {#usecases}
 
 Multipath TCP has been tested in several use cases. There is already
 an abundant scientific literature on Multipath TCP {{MPTCPBIB}}.
-Several of the papers published in the scientific litterature have
+Several of the papers published in the scientific literature have
 identified possible improvements that are worth being discussed here.
 
 Datacenters {#dc}
@@ -446,7 +446,7 @@ Although ECMP is widely used inside datacenters, this is not the only
 environment where there are different paths between a pair of hosts.
 ECMP and other load balancing techniques such as Link Aggregation
 Groups (LAG) are widely used
-in today's network and having multiple paths between a pair of
+in today's networks and having multiple paths between a pair of
 single-homed hosts is becoming the norm instead of the exception.
 Although these multiple paths have often the same cost (from an IGP
 metrics viewpoint), they do not necessarily have the same performance.
@@ -645,7 +645,7 @@ creates a normal TCP connection, it is intercepted by the Hybrid CPE
 (HPCE) that converts it in a Multipath TCP connection so that it
 can use the available access networks (DSL and LTE in the example).
 The Hybrid Access Gateway (HAG) does the opposite to ensure that the
-regular server see a normal TCP connection. Some of the solutions
+regular server sees a normal TCP connection. Some of the solutions
 that are currently discussed for hybrid networks use
 Multipath TCP on the HCPE and the HAG. Other solutions rely on
 tunnels between the HCPE and the
@@ -662,7 +662,7 @@ client --- HCPE ------ DSL ------- HAG --- internet --- server
 {: #fighybrid title="Hybrid Access Network"}
 
 
-Operational Experience
+Operational Experience {#operexp}
 ======================
 
 
@@ -771,7 +771,7 @@ control scheme is also an adaptation of the NewReno single path
 congestion control scheme to support multiple paths. Simulations and
 measurements have shown that it provides some performance benefits
 compared to the the default congestion control scheme
-{{CONEXT12}}. Measurement over a wide range of parameters reported in
+{{CONEXT12}}. Measurements over a wide range of parameters reported in
 {{CONEXT13}} also indicate some benefits with the OLIA congestion
 control scheme. Recently, a delay-based congestion control scheme has
 been ported to the Multipath TCP implementation in the Linux
@@ -1072,8 +1072,7 @@ subflows, an MPTCP implementation must select carefully the MSS used
 to generate application data. The Linux kernel implementation 
 had various ways of selecting the MSS: minimum or maximum amongst the 
 different subflows. However, these heuristics of MSS selection can
-cause significant 
-performances issues in some environment. Consider the following 
+cause significant performance issues in some environment. Consider the following 
 example. An MPTCP connection has two established subflows that 
 respectively use a MSS of 1420 and 1428 bytes. If MPTCP selects
 the maximum,
@@ -1082,7 +1081,7 @@ MPTCP implementation will have to split the segment in two (a
 1420-byte and 8-byte segments) when pushing on the subflow with the 
 smallest MSS. The latter segment will introduce a large overhead as 
 for a single data segment 2 slots will be used in the congestion 
-window (in packets) therefore reducing by ~2 the potential throughput 
+window (in packets) therefore reducing by roughly twice the potential throughput 
 (in bytes/s) of this subflow. Taking the smallest MSS does not solve 
 the issue as there might be a case where the subflow with the smallest 
 MSS only sends a few packets
@@ -1135,7 +1134,7 @@ Multipath TCP session from cdn1 or cdn2 would potentially use both
 the cellular network and the WiFi network. Serving the client from
 cdn2 over the cellular interface could violate the
 contract between the CDN provider and the network operators. A similar
-problem occurs with regular TCP if the client caches DNS replies. From
+problem occurs with regular TCP if the client caches DNS replies. For
 example the client obtains a DNS answer over the cellular interface
 and then stops this interface and starts to use its WiFi interface. If
 the client retrieves data from cdn1 over its WiFi interface, this may

--- a/draft-bonaventure-mptcp-experience.md
+++ b/draft-bonaventure-mptcp-experience.md
@@ -47,6 +47,7 @@ informative:
   I-D.hampel-mptcp-proxies-anchors:
   I-D.deng-mptcp-proxy:
   I-D.paasch-mptcp-syncookies:
+  I-D.paasch-mptcp-loadbalancer:
   MBTest:
     title: MBTest
     author:
@@ -318,6 +319,17 @@ informative:
     seriesinfo: Mobicom 2015 (Poster)
     date: Sept. 2015
     target: 
+  Presto08:
+    title: Towards a Next Generation Data Center Architecture -  Scalability and Commoditization
+    author:
+      - ins: A. Greenberg
+      - ins: P. Lahiri
+      - ins: D. Maltz
+      - ins: P. Parveen
+      - ins: S. Sengupta
+    seriesinfo: ACM PRESTO 2008
+    date: Aug. 2008
+    target: http://dl.acm.org/citation.cfm?id=1397732
   HotMiddlebox13b:
     title: Multipath in the Middle(Box)
     author:
@@ -1213,6 +1225,33 @@ regular TCP in those lossy environments.
 handshake mechanism that ensures reliable delivery of the MP_CAPABLE, following
 the 3-way handshake. This modification will make MPTCP reliable, even in lossy
 environments when servers need to use SYN-cookies to protect against SYN-flooding attacks.
+
+
+Loadbalanced serverfarms
+------------------------
+
+Large-scale serverfarms typically deploy thousands of servers behind a single
+virtual IP (VIP). Steering traffic to these servers is done through layer-4 loadbalancers
+that ensure that a TCP-flow will always be routed to the same server {{Presto08}}.
+
+As Multipath TCP uses multiple different TCP subflows to steer the traffic across
+the different paths, loadbalancers need to ensure that all these subflows are
+routed to the same server. This implies that the loadbalancers need to track
+the MPTCP-related state, allowing them to parse the token in the MP_JOIN and assign
+those subflows to the appropriate server. However, serverfarms typically deploy
+multiple of these loadbalancers for reliability and capacity reasons. As a
+TCP subflow might get routed to any of these loadbalancers, they
+would need to synchronize the MPTCP-related state - a solution that is not feasible
+at large scale.
+
+The token (carried in the MP_JOIN) contains the information indicating which
+MPTCP-session the subflow belongs to. As the token is a hash of the key, servers
+are not able to generate the token in such a way that the token can provide the
+necessary information to the loadbalancers which would allow them to
+route TCP subflows to the appropriate server. {{I-D.paasch-mptcp-loadbalancer}}
+discusses this issue in detail and suggests two alternative MP_CAPABLE handshakes
+to overcome these. As of September 2015, it is not yet clear how MPTCP might accomodate
+such use-case to enable its deployment within loadbalanced serverfarms.
 
 
 Conclusion

--- a/draft-bonaventure-mptcp-experience.md
+++ b/draft-bonaventure-mptcp-experience.md
@@ -22,8 +22,8 @@ author:
  -
   ins: C. Paasch
   name: Christoph Paasch
-  organization: UCLouvain
-  email: Christoph.Paasch@gmail.com
+  organization: Apple, Inc.
+  email: cpaasch@apple.com
  -
   ins: G. Detal
   name: Gregory Detal

--- a/draft-bonaventure-mptcp-experience.md
+++ b/draft-bonaventure-mptcp-experience.md
@@ -1227,7 +1227,7 @@ the 3-way handshake. This modification will make MPTCP reliable, even in lossy
 environments when servers need to use SYN-cookies to protect against SYN-flooding attacks.
 
 
-Loadbalanced serverfarms
+Loadbalanced serverfarms {#loadbalancer}
 ------------------------
 
 Large-scale serverfarms typically deploy thousands of servers behind a single
@@ -1300,4 +1300,9 @@ This section should be removed before final publication
 - version ietf-03 : September 2015, answer to comments from Phil
   Eardley
 
-   - 
+    - Improved introduction
+    - Added details about using SOCKS and Korea Telecom's use-case in {{proxy}}.
+    - Added issue around clients caching DNS-results in {{cdn}}
+    - Explained issue of MPTCP with stateless webservers {{syncookies}}
+    - Added description of MPTCP's use behind layer-4 loadbalancers {{loadbalancer}}
+    - Restructured text and improved writing in some parts

--- a/draft-bonaventure-mptcp-experience.md
+++ b/draft-bonaventure-mptcp-experience.md
@@ -33,6 +33,7 @@ author:
 informative:
   RFC1812:
   RFC1928:
+  RFC4987:
   RFC6182:
   RFC6356:
   RFC6824:
@@ -45,6 +46,7 @@ informative:
   I-D.wei-mptcp-proxy-mechanism:
   I-D.hampel-mptcp-proxies-anchors:
   I-D.deng-mptcp-proxy:
+  I-D.paasch-mptcp-syncookies:
   MBTest:
     title: MBTest
     author:
@@ -1182,6 +1184,35 @@ WiFi interface to send its DNS request and create the first subflow.
 This is not optimal with Multipath TCP. A better approach would
 probably be to try a few attempts on the WiFi interface and then try
 to use the second interface for the initial subflow as well.
+
+
+Stateless webservers {#syncookies}
+--------------------
+
+MPTCP has been designed to interoperate with webservers that benefit from SYN-cookies
+to protect against SYN-flooding attacks {{RFC4987}}. MPTCP achieves this by
+echoing the keys negotiated during the MP_CAPABLE handshake in the third ACK of the 3-way handshake.
+Reception of this third ACK then allows the server to reconstruct the state
+specific to MPTCP.
+
+However, one caveat to this mechanism is the non-reliable nature of the third ACK.
+Indeed, when the third ACK gets lost, the server will not be able to reconstruct
+the MPTCP-state. MPTCP will fallback to regular TCP in this case.
+This is in contrast to regular TCP, as clients usually start the
+application's transaction by sending data to the server. This data-segment (that
+is sent reliably by TCP) enables stateless servers to create the TCP-related state,
+even in case the third ACK has been lost.
+
+This issue might be considered as a minor one for MPTCP. Losing the third ACK
+should only happen when packet loss is high. However, when packet-loss
+is high MPTCP provides a lot of benefits as it can move traffic away from the
+lossy link. It is undesirable that MPTCP has a higher chance to fall back to
+regular TCP in those lossy environments.
+
+{{I-D.paasch-mptcp-syncookies}} discusses this issue and suggests a modified
+handshake mechanism that ensures reliable delivery of the MP_CAPABLE, following
+the 3-way handshake. This modification will make MPTCP reliable, even in lossy
+environments when servers need to use SYN-cookies to protect against SYN-flooding attacks.
 
 
 Conclusion


### PR DESCRIPTION
Adding experience of using MPTCP with SYN-cookies and MPTCP behind loadbalancers to the operational experience section.
